### PR TITLE
fix compile error for GCC due to resolution of uint64_t type.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR    := build
 LIB_DIR      := lib
 
 # -------- tools/flags --------
-CC      := clang
+CC      := gcc
 CFLAGS  := -O2 -Wall -Wextra -Wpedantic -Wshadow -g -fopenmp
 INCLUDES := -Iinclude -I$(SRC_DIR) -I$(NEURON_DIR)
 INCLUDES += -I/usr/include/openblas

--- a/src/neurons/flif_diffusive.c
+++ b/src/neurons/flif_diffusive.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <math.h>
 #include <string.h>
 
@@ -8,9 +9,9 @@
 
 // ---------------- RNG (SplitMix64) ----------------
 static inline uint64_t splitmix64_next(uint64_t *x) {
-    uint64_t z = (*x += 0x9E3779B97f4A7C15ULL);
-    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
-    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    uint64_t z = (*x += UINT64_C(0x9E3779B97f4A7C15));
+    z = (z ^ (z >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)) * UINT64_C(0x94D049BB133111EB);
     return z ^ (z >> 31);
 }
 
@@ -116,11 +117,11 @@ struct flif_diffusive_neuron* init_flif_diffusive(double* params, double dt)
     }
 
     // Seed RNG deterministically from pointer + params (use 64-bit chunks of the doubles)
-    uint64_t seed = 0x9E3779B97f4A7C15ULL ^ (uintptr_t)n;
+    uint64_t seed = UINT64_C(0x9E3779B97f4A7C15) ^ (uintptr_t)n;
     for (int i=0;i<8;i++) {
         uint64_t bits = 0;
         memcpy(&bits, &params[i], sizeof(bits));
-        seed ^= bits + 0x9E3779B97f4A7C15ULL;
+        seed ^= bits + UINT64_C(0x9E3779B97f4A7C15);
         seed = splitmix64_next(&seed);
     }
     n->rng = seed;
@@ -128,10 +129,10 @@ struct flif_diffusive_neuron* init_flif_diffusive(double* params, double dt)
     return n;
 }
 
-void flif_diffusive_set_seed(struct flif_diffusive_neuron* n, unsigned long long seed)
+void flif_diffusive_set_seed(struct flif_diffusive_neuron* n, uint64_t seed)
 {
     if (!n) return;
-    if (seed == 0ULL) seed = 0xD1B54A32D192ED03ULL;
+    if (seed == UINT64_C(0)) seed = UINT64_C(0xD1B54A32D192ED03);
     n->rng = (uint64_t)seed;
     (void)splitmix64_next(&n->rng);
     (void)splitmix64_next(&n->rng);

--- a/src/neurons/flif_diffusive.h
+++ b/src/neurons/flif_diffusive.h
@@ -41,6 +41,7 @@ extern "C" {
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct flif_diffusive_neuron {
     // Parameters (double precision)
@@ -64,7 +65,7 @@ struct flif_diffusive_neuron {
     double g_euler;           // dt / tau_m
 
     // RNG state (SplitMix64)
-    unsigned long long rng;
+    uint64_t rng;
 };
 
 // API (double throughout)
@@ -73,7 +74,7 @@ void   update_flif_diffusive(struct flif_diffusive_neuron* n, double input, doub
 void   free_flif_diffusive(struct flif_diffusive_neuron* n);
 
 // Optional deterministic seeding for reproducibility
-void   flif_diffusive_set_seed(struct flif_diffusive_neuron* n, unsigned long long seed);
+void   flif_diffusive_set_seed(struct flif_diffusive_neuron* n, uint64_t seed);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
when compiling with GCC I received the following error:
```
src/neurons/flif_diffusive.c:11:50: note: expected ‘uint64_t *’ {aka ‘long unsigned int *’} but argument is of type ‘long long unsigned int *’
   11 | static inline uint64_t splitmix64_next(uint64_t *x) {
```

I found that this is due to the following architecture dependency; compiling on a 32bit system resolves `uint64_t` to `unsigned long long int`, while compiling on a 64bit system resolves `uint64_t` to `unsigned long int`.

this fix assumes we want 64 bit types, so it uses the `<inttypes.h>` header to resolve the variable assignments to be 64 bits for each architecture, and changes explicit `unsigned long long` type declarations to `uint64_t`.

tested on Fedora 43 and this fix compiled for both GCC 15.2.1 and Clang 21.1.8.